### PR TITLE
Fixes to measuretoas

### DIFF
--- a/src/crimp/measureToAs.py
+++ b/src/crimp/measureToAs.py
@@ -271,7 +271,7 @@ def measureToAs(evtFile, timMod, tempModPP, toagtifile, eneLow=0.5, eneHigh=10.,
     # Creating .tim file if specified
     #################################
     if timFile is not None:  # if given convert ToAs.txt to a .tim file
-        phshiftTotimfile(toaFile + '.txt', timMod, toaFile, tempModPP=tempModPP)
+        phshiftTotimfile(toaFile + '.txt', timMod, timFile, tempModPP=tempModPP)
         logger.info('\n Wrote timfile {}.tim'.format(timFile))
 
     # Plotting Phase residuals of all ToAs

--- a/src/crimp/phshiftTotimfile.py
+++ b/src/crimp/phshiftTotimfile.py
@@ -107,7 +107,7 @@ def phshiftTotimfile(ToAs, timMod, timfile='residuals', tempModPP='ppTemplateMod
     pulsenumber = np.zeros(nbrToAs)
 
     for ii in range(nbrToAs):
-        ephemerides_intRot = ephemIntegerRotation([tToA_MJD[ii]], timMod)
+        ephemerides_intRot = ephemIntegerRotation(np.array([tToA_MJD[ii]]), timMod)
 
         # Time corresponding to phase shift 
         deltaT = dph[ii] * (1 / ephemerides_intRot["freq_intRotation"])

--- a/src/crimp/phshiftTotimfile.py
+++ b/src/crimp/phshiftTotimfile.py
@@ -107,7 +107,7 @@ def phshiftTotimfile(ToAs, timMod, timfile='residuals', tempModPP='ppTemplateMod
     pulsenumber = np.zeros(nbrToAs)
 
     for ii in range(nbrToAs):
-        ephemerides_intRot = ephemIntegerRotation(tToA_MJD[ii], timMod)
+        ephemerides_intRot = ephemIntegerRotation([tToA_MJD[ii]], timMod)
 
         # Time corresponding to phase shift 
         deltaT = dph[ii] * (1 / ephemerides_intRot["freq_intRotation"])


### PR DESCRIPTION
When phshiftTotimfile is called, ephemIntegerRotation is called on each ToA individually; however, when measuretoas is used, it is treated as a list. In this PR, I cast the single ToA as an array. Also, the -mf flag wasn't properly renaming the output .tim file. Addresses #1 and #2. 